### PR TITLE
Jlou/cosmotech copilot api

### DIFF
--- a/charts/cosmotech-copilot-api/.helmignore
+++ b/charts/cosmotech-copilot-api/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cosmotech-copilot-api/Chart.yaml
+++ b/charts/cosmotech-copilot-api/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: cosmotech-copilot-api
+description: Cosmo Tech Copilot API
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/charts/cosmotech-copilot-api/templates/_helpers.tpl
+++ b/charts/cosmotech-copilot-api/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Context path:
+This path will follow the pattern /{rootName}/{namespace|tenantId}/{apiVersion}
+E.g:
+- /myTenant/v1
+*/}}
+{{- define "cosmotech-api.contextPath" -}}
+{{- if eq (index .Values "cosmotech-api" "multiTenant") "true" }}
+{{- printf "/%s/%s" .Release.Namespace (index .Values "cosmotech-api" "version") }}
+{{- else }}
+{{- printf "/%s" (index .Values "cosmotech-api" "version") }}
+{{- end }}
+{{- end }}

--- a/charts/cosmotech-copilot-api/templates/_helpers.tpl
+++ b/charts/cosmotech-copilot-api/templates/_helpers.tpl
@@ -8,19 +8,12 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
 */}}
 {{- define "cosmotech-copilot-api.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- $releaseName := .Release.Name }}
-{{- if or (contains $name $releaseName) (contains $releaseName $name) (eq $name "cosmotech-copilot-api") }}
-{{- $releaseName | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 

--- a/charts/cosmotech-copilot-api/templates/_helpers.tpl
+++ b/charts/cosmotech-copilot-api/templates/_helpers.tpl
@@ -63,14 +63,10 @@ Create the name of the service account to use
 
 {{/*
 Context path:
-This path will follow the pattern /{rootName}/{namespace|tenantId}/{apiVersion}
+This path will follow the pattern /{namespace}/{apiVersion}/{appPath}
 E.g:
-- /myTenant/v1
+- /phoenix/v3-1/copilot
 */}}
 {{- define "cosmotech-api.contextPath" -}}
-{{- if eq (index .Values "cosmotech-api" "multiTenant") "true" }}
-{{- printf "/%s/%s" .Release.Namespace (index .Values "cosmotech-api" "version") }}
-{{- else }}
-{{- printf "/%s" (index .Values "cosmotech-api" "version") }}
-{{- end }}
+{{- printf "/%s/%s/%s" .Release.Namespace (index .Values "cosmotech-api" "version") .Values.ingress.appPath }}
 {{- end }}

--- a/charts/cosmotech-copilot-api/templates/_helpers.tpl
+++ b/charts/cosmotech-copilot-api/templates/_helpers.tpl
@@ -15,10 +15,11 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- $releaseName := .Release.Name }}
+{{- if or (contains $name $releaseName) (contains $releaseName $name) (eq $name "cosmotech-copilot-api") }}
+{{- $releaseName | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cosmotech-copilot-api/templates/_helpers.tpl
+++ b/charts/cosmotech-copilot-api/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cosmotech-copilot-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cosmotech-copilot-api.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cosmotech-copilot-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cosmotech-copilot-api.labels" -}}
+helm.sh/chart: {{ include "cosmotech-copilot-api.chart" . }}
+{{ include "cosmotech-copilot-api.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cosmotech-copilot-api.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cosmotech-copilot-api.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cosmotech-copilot-api.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cosmotech-copilot-api.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/cosmotech-copilot-api/templates/deployment.yaml
+++ b/charts/cosmotech-copilot-api/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cosmotech-copilot-api.fullname" . }}
+  labels:
+    app: {{ include "cosmotech-copilot-api.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "cosmotech-copilot-api.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "cosmotech-copilot-api.name" . }}
+    spec:
+      containers:
+      - name: {{ include "cosmotech-copilot-api.name" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+          - containerPort: {{ .Values.service.port }}
+        env:
+        {{- if .Values.env }}
+        {{- range $key, $val := .Values.env }}
+        - name: {{ $key | quote }}
+          value: {{ $val | quote }}
+        {{- end }}
+        {{- end }}

--- a/charts/cosmotech-copilot-api/templates/deployment.yaml
+++ b/charts/cosmotech-copilot-api/templates/deployment.yaml
@@ -2,28 +2,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cosmotech-copilot-api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "cosmotech-copilot-api.name" . }}
+    cosmotech.com/service: {{ include "cosmotech-copilot-api.name" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "cosmotech-copilot-api.name" . }}
+      cosmotech.com/service: {{ include "cosmotech-copilot-api.name" . }}
   template:
     metadata:
       labels:
-        app: {{ include "cosmotech-copilot-api.name" . }}
+        cosmotech.com/service: {{ include "cosmotech-copilot-api.name" . }}
     spec:
       containers:
       - name: {{ include "cosmotech-copilot-api.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-          - containerPort: {{ .Values.service.port }}
-        env:
-        {{- if .Values.env }}
-        {{- range $key, $val := .Values.env }}
-        - name: {{ $key | quote }}
-          value: {{ $val | quote }}
-        {{- end }}
-        {{- end }}
+          - name: http
+            containerPort: {{ .Values.service.port }}
+            protocol: TCP
+        envFrom:
+          - secretRef:
+              name: cosmotech-copilot-api-secret

--- a/charts/cosmotech-copilot-api/templates/ingress.yaml
+++ b/charts/cosmotech-copilot-api/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "cosmotech-copilot-api.fullname" . }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "cosmotech-copilot-api.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+{{- end }}

--- a/charts/cosmotech-copilot-api/templates/ingress.yaml
+++ b/charts/cosmotech-copilot-api/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
             port:
               number: {{ .Values.service.port | default 80 }}
         {{- $contextPath := include "cosmotech-api.contextPath" . }}
-        path: {{ $contextPath }}/copilot(/|$)(.*)
+        path: {{ $contextPath }}(/|$)(.*)
         pathType: ImplementationSpecific
   tls:
   - hosts:

--- a/charts/cosmotech-copilot-api/templates/ingress.yaml
+++ b/charts/cosmotech-copilot-api/templates/ingress.yaml
@@ -2,32 +2,36 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "cosmotech-copilot-api.fullname" . }}
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.certManagerClusterIssuer | default "letsencrypt-prod" }}
+    email: {{ .Values.ingress.email | default "platform@cosmotech.com" }}
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
+    nginx.org/client-max-body-size: "0"
+  labels:
+    owner: csm-platform
+  name: {{ .Values.ingress.name | default (include "cosmotech-copilot-api.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
 spec:
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  ingressClassName: nginx
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
-            backend:
-              service:
-                name: {{ include "cosmotech-copilot-api.fullname" $ }}
-                port:
-                  number: {{ $.Values.service.port }}
-          {{- end }}
-    {{- end }}
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Values.ingress.serviceName | default (include "cosmotech-copilot-api.fullname" .) }}
+            port:
+              number: {{ .Values.service.port | default 80 }}
+        {{- $contextPath := include "cosmotech-api.contextPath" . }}
+        path: {{ $contextPath }}/copilot(/|$)(.*)
+        pathType: ImplementationSpecific
   tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+  - hosts:
+    - {{ .Values.ingress.host }}
+    secretName: {{ .Values.ingress.tlsSecretName | default "letsencrypt-prod" }}
 {{- end }}

--- a/charts/cosmotech-copilot-api/templates/secret.yaml
+++ b/charts/cosmotech-copilot-api/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cosmotech-copilot-api-secret
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  {{- range $category, $settings := .Values.envConfig }}
+  {{- range $key, $val := $settings }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/cosmotech-copilot-api/templates/service.yaml
+++ b/charts/cosmotech-copilot-api/templates/service.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - protocol: TCP
+    - name: {{ .Values.service.targetPort }}
+      protocol: TCP
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
   selector:

--- a/charts/cosmotech-copilot-api/templates/service.yaml
+++ b/charts/cosmotech-copilot-api/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cosmotech-copilot-api.fullname" . }}
+  labels:
+    {{- include "cosmotech-copilot-api.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "cosmotech-copilot-api.selectorLabels" . | nindent 4 }}

--- a/charts/cosmotech-copilot-api/templates/service.yaml
+++ b/charts/cosmotech-copilot-api/templates/service.yaml
@@ -2,14 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cosmotech-copilot-api.fullname" . }}
-  labels:
-    {{- include "cosmotech-copilot-api.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+    - protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
   selector:
-    {{- include "cosmotech-copilot-api.selectorLabels" . | nindent 4 }}
+    cosmotech.com/service: {{ include "cosmotech-copilot-api.name" . }}

--- a/charts/cosmotech-copilot-api/templates/service.yaml
+++ b/charts/cosmotech-copilot-api/templates/service.yaml
@@ -8,6 +8,6 @@ spec:
   ports:
     - protocol: TCP
       port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
   selector:
     cosmotech.com/service: {{ include "cosmotech-copilot-api.name" . }}

--- a/charts/cosmotech-copilot-api/values.yaml
+++ b/charts/cosmotech-copilot-api/values.yaml
@@ -22,7 +22,7 @@ service:
   # Service type (ClusterIP for internal access).
   type: ClusterIP
   # Ports on which the service exposes the API.
-  port: 8080
+  port: 8082
   targetPort: http
 
 # Ingress configuration for external access to the API.

--- a/charts/cosmotech-copilot-api/values.yaml
+++ b/charts/cosmotech-copilot-api/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 # Cosmotech API values for path
 cosmotech-api:
-  version: "v3-1"
+  version: 
   multiTenant: "true"
 
 # Docker image settings for the Cosmotech Copilot API.

--- a/charts/cosmotech-copilot-api/values.yaml
+++ b/charts/cosmotech-copilot-api/values.yaml
@@ -21,8 +21,9 @@ image:
 service:
   # Service type (ClusterIP for internal access).
   type: ClusterIP
-  # Port on which the service exposes the API.
-  port: 80
+  # Ports on which the service exposes the API.
+  port: 8080
+  targetPort: 80
 
 # Ingress configuration for external access to the API.
 ingress:

--- a/charts/cosmotech-copilot-api/values.yaml
+++ b/charts/cosmotech-copilot-api/values.yaml
@@ -1,6 +1,11 @@
 # Number of API replicas to deploy.
 replicaCount: 1
 
+# Cosmotech API values for path
+cosmotech-api:
+  version: "v3-1"
+  multiTenant: "true"
+
 # Docker image settings for the Cosmotech Copilot API.
 image:
   # Repository for the API image.
@@ -21,34 +26,12 @@ service:
 ingress:
   # Enable or disable Ingress.
   enabled: true
-  # Specify the Ingress class to use (e.g., nginx).
-  ingressClassName: nginx
-  # Ingress annotations for additional configuration.
-  annotations:
-    cert-manager.io/cluster-issuer: "" 
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
-    nginx.org/client-max-body-size: "0"
-  hosts:
-    - 
-      # Domain name for the API (e.g., dev.api.cosmotech.com).
-      host: ""
-      paths:
-        - 
-          # Ingress path to route to the API.
-          path: ""
-          pathType: ImplementationSpecific
-  tls:
-    - 
-      # List of hosts for TLS termination.
-      hosts:
-        - ""
-      # Name of the TLS secret for the Ingress.
-      secretName: ""
+  host: example.api.cosmotech.com
+  name: cosmotech-copilot-api
+  serviceName: cosmotech-copilot-api
+  tlsSecretName: letsencrypt-prod
+  certManagerClusterIssuer: letsencrypt-prod
+  email: platform@cosmotech.com
 
 # Structured environment variables grouped by category.
 envConfig:

--- a/charts/cosmotech-copilot-api/values.yaml
+++ b/charts/cosmotech-copilot-api/values.yaml
@@ -1,10 +1,12 @@
+nameOverride: "" 
+fullnameOverride: "" 
+
 # Number of API replicas to deploy.
 replicaCount: 1
 
 # Cosmotech API values for path
 cosmotech-api:
   version: 
-  multiTenant: "true"
 
 # Docker image settings for the Cosmotech Copilot API.
 image:
@@ -32,6 +34,7 @@ ingress:
   tlsSecretName: letsencrypt-prod
   certManagerClusterIssuer: letsencrypt-prod
   email: platform@cosmotech.com
+  appPath: "copilot"
 
 # Structured environment variables grouped by category.
 envConfig:

--- a/charts/cosmotech-copilot-api/values.yaml
+++ b/charts/cosmotech-copilot-api/values.yaml
@@ -1,19 +1,31 @@
+# Number of API replicas to deploy.
 replicaCount: 1
 
+# Docker image settings for the Cosmotech Copilot API.
 image:
+  # Repository for the API image.
   repository: ghcr.io/cosmo-tech/cosmotech-copilot-api
+  # Tag for the image.
   tag: "latest"
+  # Pull policy for the image.
   pullPolicy: IfNotPresent
 
+# Service settings to expose the API inside the cluster.
 service:
+  # Service type (ClusterIP for internal access).
   type: ClusterIP
+  # Port on which the service exposes the API.
   port: 80
 
+# Ingress configuration for external access to the API.
 ingress:
+  # Enable or disable Ingress.
   enabled: true
+  # Specify the Ingress class to use (e.g., nginx).
   ingressClassName: nginx
+  # Ingress annotations for additional configuration.
   annotations:
-    cert-manager.io/cluster-issuer: ""
+    cert-manager.io/cluster-issuer: "" 
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: "/$2"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
@@ -22,55 +34,107 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
     nginx.org/client-max-body-size: "0"
   hosts:
-    - host: 
+    - 
+      # Domain name for the API (e.g., dev.api.cosmotech.com).
+      host: ""
       paths:
-        - path: 
+        - 
+          # Ingress path to route to the API.
+          path: ""
           pathType: ImplementationSpecific
   tls:
-    - hosts:
-      secretName: 
+    - 
+      # List of hosts for TLS termination.
+      hosts:
+        - ""
+      # Name of the TLS secret for the Ingress.
+      secretName: ""
 
+# Structured environment variables grouped by category.
 envConfig:
+  # Settings for application mode.
   modeSettings:
+    # Application mode: 'supply-chain' or 'assets'.
     MODE: ""
+    # The port on which the API listens.
     PORT: ""
+    # Cloud provider for the AI service.
     AI_PROVIDER: ""
+  # Settings for Azure Data Explorer (ADX).
   adxSettings:
+    # Azure AD tenant ID for ADX access.
     AAD_TENANT_ID: ""
+    # URL of the Kusto (ADX) cluster.
     KUSTO_CLUSTER_URL: ""
+    # Name of the Kusto database.
     KUSTO_DATABASE: ""
+    # Azure AD Application ID for ADX ingestion.
     ADX_AAD_APP_ID: ""
+    # Secret for the Azure AD Application used with ADX.
     ADX_AAD_SECRET: ""
+    # Number of rows to retrieve from ADX.
     ADX_RETRIEVED_ROW_NB: ""
+  # Vector store configuration.
   vectorStore:
+    # Flag indicating whether to use a local vector store (FAISS) or Azure AI Search.
     IS_VECTOR_STORE_LOCAL: ""
+    # File path to load local context for the vector store.
     CONTEXT_FILE_PATH: ""
+  # Settings for Azure AI Search.
   searchSettings:
+    # Endpoint URL for Azure AI Search.
     SEARCH_ENDPOINT_URL: ""
+    # API key for Azure AI Search.
     SEARCH_API_KEY: ""
+    # Name of the search index.
     INDEX_NAME: ""
+    # Default number of documents to retrieve.
     RETRIEVED_DOCUMENT_NB: "5"
+    # Size (in tokens) for splitting documents into chunks.
     CHUNK_SIZE: ""
+    # Number of tokens to overlap between chunks.
     CHUNK_OVERLAP: ""
+  # Settings for Azure Open AI.
   openAiSettings:
+    # Endpoint URL for Azure Open AI.
     AZURE_OPEN_AI_ENDPOINT: ""
+    # API key for Azure Open AI.
     AZURE_OPEN_AI_API_KEY: ""
-    AZURE_OPEN_AI_API_TYPE: ""
+    # API type (typically "azure").
+    AZURE_OPEN_AI_API_TYPE: "azure"
+    # API version for Azure Open AI.
     AZURE_OPEN_AI_API_VERSION: ""
+    # Deployment name for the LLM model.
     LLM_DEPLOYMENT_NAME: ""
+    # Deployment name for the embeddings model.
     EMBEDDINGS_DEPLOYEMENT_NAME: ""
+    # Temperature parameter for LLM generation.
     TEMPERATURE: ""
+    # Maximum tokens for LLM responses.
     MAX_TOKEN: ""
+    # Flag to enable streaming responses.
     STREAMING: ""
+  # Settings for the Azure Bot.
   botSettings:
+    # Azure Bot Application ID.
     AZURE_BOT_APP_ID: ""
+    # Password for the Azure Bot.
     AZURE_BOT_PASSWORD: ""
+    # DirectLine secret for the Azure Bot.
     AZURE_BOT_DIRECTLINE_SECRET: ""
+  # Cosmo Tech API connection credentials.
   cosmotechApi:
+    # Host URL for the Cosmo Tech API.
     COMOSTECH_API_HOST: ""
+    # Scope for the Cosmo Tech API.
     COSMOTECH_API_SCOPE: ""
+    # Tenant ID for the Cosmo Tech API.
     COMOSTECH_API_TENANT_ID: ""
+    # Client ID for the Cosmo Tech API.
     COSMOTECH_API_CLIENT_ID: ""
+    # Client secret for the Cosmo Tech API.
     COSMOTECH_API_CLIENT_SECRET: ""
+    # Organization ID
     ORGANIZATION: ""
+    # Workspace ID
     WORKSPACE: ""

--- a/charts/cosmotech-copilot-api/values.yaml
+++ b/charts/cosmotech-copilot-api/values.yaml
@@ -23,7 +23,7 @@ service:
   type: ClusterIP
   # Ports on which the service exposes the API.
   port: 8080
-  targetPort: 80
+  targetPort: http
 
 # Ingress configuration for external access to the API.
 ingress:

--- a/charts/cosmotech-copilot-api/values.yaml
+++ b/charts/cosmotech-copilot-api/values.yaml
@@ -1,0 +1,76 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/cosmo-tech/cosmotech-copilot-api
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: ""
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
+    nginx.org/client-max-body-size: "0"
+  hosts:
+    - host: 
+      paths:
+        - path: 
+          pathType: ImplementationSpecific
+  tls:
+    - hosts:
+      secretName: 
+
+envConfig:
+  modeSettings:
+    MODE: ""
+    PORT: ""
+    AI_PROVIDER: ""
+  adxSettings:
+    AAD_TENANT_ID: ""
+    KUSTO_CLUSTER_URL: ""
+    KUSTO_DATABASE: ""
+    ADX_AAD_APP_ID: ""
+    ADX_AAD_SECRET: ""
+    ADX_RETRIEVED_ROW_NB: ""
+  vectorStore:
+    IS_VECTOR_STORE_LOCAL: ""
+    CONTEXT_FILE_PATH: ""
+  searchSettings:
+    SEARCH_ENDPOINT_URL: ""
+    SEARCH_API_KEY: ""
+    INDEX_NAME: ""
+    RETRIEVED_DOCUMENT_NB: "5"
+    CHUNK_SIZE: ""
+    CHUNK_OVERLAP: ""
+  openAiSettings:
+    AZURE_OPEN_AI_ENDPOINT: ""
+    AZURE_OPEN_AI_API_KEY: ""
+    AZURE_OPEN_AI_API_TYPE: ""
+    AZURE_OPEN_AI_API_VERSION: ""
+    LLM_DEPLOYMENT_NAME: ""
+    EMBEDDINGS_DEPLOYEMENT_NAME: ""
+    TEMPERATURE: ""
+    MAX_TOKEN: ""
+    STREAMING: ""
+  botSettings:
+    AZURE_BOT_APP_ID: ""
+    AZURE_BOT_PASSWORD: ""
+    AZURE_BOT_DIRECTLINE_SECRET: ""
+  cosmotechApi:
+    COMOSTECH_API_HOST: ""
+    COSMOTECH_API_SCOPE: ""
+    COMOSTECH_API_TENANT_ID: ""
+    COSMOTECH_API_CLIENT_ID: ""
+    COSMOTECH_API_CLIENT_SECRET: ""
+    ORGANIZATION: ""
+    WORKSPACE: ""


### PR DESCRIPTION
Helm Chart for cosmotech-copilot-api service

This PR introduces a Helm chart for deploying the cosmotech-copilot-api.

Created deployment, service, secret and ingress templates 

Set up environment variables through a Kubernetes Secret for improved security

The chart has been tested with helm install --dry-run to validate template rendering.
