### PR TITLE
fix: networking traffic allowed

### DIFF
--- a/charts/cosmotech-copilot-api/templates/_helpers.tpl
+++ b/charts/cosmotech-copilot-api/templates/_helpers.tpl
@@ -45,6 +45,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Default Network policy
+*/}}
+{{- define "cosmotech-copilot-api.defaultNetworkPolicy" -}}
+{{- if .Values.networkPolicy.enabled }}
+"networking/traffic-allowed": "yes"
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "cosmotech-copilot-api.serviceAccountName" -}}

--- a/charts/cosmotech-copilot-api/templates/deployment.yaml
+++ b/charts/cosmotech-copilot-api/templates/deployment.yaml
@@ -10,10 +10,12 @@ spec:
   selector:
     matchLabels:
       cosmotech.com/service: {{ include "cosmotech-copilot-api.name" . }}
+      networking/traffic-allowed: "yes"
   template:
     metadata:
       labels:
         cosmotech.com/service: {{ include "cosmotech-copilot-api.name" . }}
+        networking/traffic-allowed: "yes"
     spec:
       containers:
       - name: {{ include "cosmotech-copilot-api.name" . }}

--- a/charts/cosmotech-copilot-api/templates/deployment.yaml
+++ b/charts/cosmotech-copilot-api/templates/deployment.yaml
@@ -10,12 +10,12 @@ spec:
   selector:
     matchLabels:
       cosmotech.com/service: {{ include "cosmotech-copilot-api.name" . }}
-      networking/traffic-allowed: "yes"
+      {{- include "cosmotech-copilot-api.defaultNetworkPolicy" . | nindent 6 }}
   template:
     metadata:
       labels:
         cosmotech.com/service: {{ include "cosmotech-copilot-api.name" . }}
-        networking/traffic-allowed: "yes"
+        {{- include "cosmotech-copilot-api.defaultNetworkPolicy" . | nindent 8 }}
     spec:
       containers:
       - name: {{ include "cosmotech-copilot-api.name" . }}

--- a/charts/cosmotech-copilot-api/values.yaml
+++ b/charts/cosmotech-copilot-api/values.yaml
@@ -25,6 +25,10 @@ service:
   port: 8082
   targetPort: http
 
+# Enables NetworkPolicy
+networkPolicy:
+  enabled: true
+
 # Ingress configuration for external access to the API.
 ingress:
   # Enable or disable Ingress.


### PR DESCRIPTION
J'ai ajouté `networking/traffic-allowed: "yes"` pour autoriser la communication réseau ou  pod, car il y a une NetworkPolicy sur le cluster.
```
 spec:
  podSelector:
    matchLabels:
      networking/traffic-allowed: "yes"
```