### PR TITLE
Update chart version to 5.0.0-beta2 and remove persistence

### DIFF
--- a/charts/cosmotech-api/Chart.yaml
+++ b/charts/cosmotech-api/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.0.0-beta1
+version: 5.0.0-beta2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.0-beta1"
+appVersion: "5.0.0-beta2"

--- a/charts/cosmotech-api/README.md
+++ b/charts/cosmotech-api/README.md
@@ -1,6 +1,6 @@
 # cosmotech-api
 
-![Version: 5.0.0-beta1](https://img.shields.io/badge/Version-5.0.0--beta1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.0.0-beta1](https://img.shields.io/badge/AppVersion-5.0.0--beta1-informational?style=flat-square)
+![Version: 5.0.0-beta2](https://img.shields.io/badge/Version-5.0.0--beta2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.0.0-beta2](https://img.shields.io/badge/AppVersion-5.0.0--beta2-informational?style=flat-square)
 
 Cosmo Tech Platform API
 
@@ -600,7 +600,7 @@ helm repo update
 Deploy the Cosmo Tech API using the Helm chart with the specified values:
 
 ```bash
-helm install ${RELEASE_NAME} cosmotech/cosmotech-api --namespace ${NAMESPACE} --version "5.0.0-beta1" --values - <<EOF
+helm install ${RELEASE_NAME} cosmotech/cosmotech-api --namespace ${NAMESPACE} --version "5.0.0-beta2" --values - <<EOF
 replicaCount: ${API_REPLICAS}
 api:
   version: ${API_VERSION_PATH}
@@ -711,13 +711,6 @@ resources:
     memory: 1024Mi
 networkPolicy:
   enabled: true
-persistence:
-  # -- Enable the data storage persistence
-  enabled: true
-  # -- PVC storage request for the data volume
-  size: 8Gi
-  # -- PVC storage class for the data volume, currently requires a ReadWriteMany capability
-  storageClass: ""
 EOF
 ```
 

--- a/charts/cosmotech-api/values.yaml
+++ b/charts/cosmotech-api/values.yaml
@@ -136,14 +136,6 @@ resources:
     cpu: 500m
     memory: 512Mi
 
-persistence:
-  # -- Enable the data storage persistence
-  enabled: true
-  # -- PVC storage request for the data volume
-  size: 8Gi
-  # -- PVC storage class for the data volume, currently requires a ReadWriteMany capability
-  storageClass: ""
-
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
Bumped chart and app versions to 5.0.0-beta2. 
Removed persistence configuration, including storage settings, from the Helm values and README for simplification. 
Adjusted related documentation and examples accordingly.