### PR TITLE
Modeling api 0.1.0

### DIFF
--- a/charts/cosmotech-modeling-api/Chart.yaml
+++ b/charts/cosmotech-modeling-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: cosmotech-modeling-api
+description: Helm chart for Cosmo Tech Modeling API
+type: application
+version: 0.1.0

--- a/charts/cosmotech-modeling-api/templates/_helpers.tpl
+++ b/charts/cosmotech-modeling-api/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cosmotech-modeling-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cosmotech-modeling-api.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cosmotech-modeling-api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+App version
+*/}}
+{{- define "cosmotech-modeling-api.appVersion" -}}
+{{- .Values.image.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cosmotech-modeling-api.labels" -}}
+helm.sh/chart: {{ include "cosmotech-modeling-api.chart" . }}
+{{ include "cosmotech-modeling-api.selectorLabels" . }}
+app.kubernetes.io/version: {{ include "cosmotech-modeling-api.appVersion" . | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cosmotech-modeling-api.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cosmotech-modeling-api.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create docker secret for pulling the image
+*/}}
+{{- define "cosmotech-modeling-api.imagePullSecret" -}}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.image.credentials.registry (printf "%s:%s" .Values.image.credentials.username .Values.image.credentials.password | b64enc) | b64enc }}
+{{- end }}

--- a/charts/cosmotech-modeling-api/templates/deployment.yaml
+++ b/charts/cosmotech-modeling-api/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cosmotech-modeling-api.fullname" . }}
+  labels:
+    {{- include "cosmotech-modeling-api.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "cosmotech-modeling-api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "cosmotech-modeling-api.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.image.credentials.registry }}
+      imagePullSecrets:
+        - name: {{ include "cosmotech-modeling-api.fullname" . }}-registry
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ include "cosmotech-modeling-api.appVersion" . }}"
+          command: ["csm-modeling-server"]
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9100
+              protocol: TCP
+          env:
+            - name: CSM_BUILDIMAGE_REPOSITORY
+              value: {{ .Values.image.repository }}
+            - name: CSM_BUILDIMAGE_PULLSECRET
+              value: {{ include "cosmotech-modeling-api.fullname" . }}-registry
+            {{- with .Values.config.apiSettings }}
+            - name: CSM_COSMOTECHAPI_SETTINGS
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.config.argoSettings }}
+            - name: CSM_ARGOWORKFLOWS_SETTINGS
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.config.s3.user }}
+            - name: AWS_ACCESS_KEY_ID
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            {{- with .Values.config.s3.password }}
+            - name: AWS_SECRET_ACCESS_KEY
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resource | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/cosmotech-modeling-api/templates/registry.secret.yaml
+++ b/charts/cosmotech-modeling-api/templates/registry.secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.image.credentials.registry }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cosmotech-modeling-api.fullname" . }}-registry
+  labels:
+    {{- include "cosmotech-modeling-api.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "cosmotech-modeling-api.imagePullSecret" . }}
+{{- end }}

--- a/charts/cosmotech-modeling-api/templates/service.yaml
+++ b/charts/cosmotech-modeling-api/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cosmotech-modeling-api.fullname" . }}
+  labels:
+    {{- include "cosmotech-modeling-api.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: http
+    {{- if .Values.serviceMonitor.enabled }}
+    - name: metrics
+      port: {{ .Values.serviceMonitor.port }}
+      protocol: TCP
+      targetPort: metrics
+    {{- end }}
+  selector:
+    {{- include "cosmotech-modeling-api.selectorLabels" . | nindent 4 }}

--- a/charts/cosmotech-modeling-api/templates/servicemonitor.yaml
+++ b/charts/cosmotech-modeling-api/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cosmotech-modeling-api.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  labels:
+    {{- include "cosmotech-modeling-api.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - port: metrics
+      path: "/metrics"
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "cosmotech-modeling-api.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/cosmotech-modeling-api/templates/tests/connection.yaml
+++ b/charts/cosmotech-modeling-api/templates/tests/connection.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "cosmotech-modeling-api.fullname" . }}-test-connection"
+  labels:
+    {{- include "cosmotech-modeling-api.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: hook-succeeded
+spec:
+  nodeSelector:
+    cosmotech.com/tier: services
+  tolerations:
+    - key: vendor
+      value: cosmotech
+      effect: NoSchedule
+  containers:
+    - name: wget-endpoints
+      image: busybox
+      command: ['wget']
+      args:
+        - '--quiet'
+        - '--server-response'
+        - '--output-document=-'
+        - 'http://{{ include "cosmotech-modeling-api.fullname" . }}:{{ .Values.service.port }}/about'
+        - 'http://{{ include "cosmotech-modeling-api.fullname" . }}:{{ .Values.service.port }}/openapi.yaml'
+        {{- if .Values.serviceMonitor.enabled }}
+        - 'http://{{ include "cosmotech-modeling-api.fullname" . }}:{{ .Values.serviceMonitor.port }}/metrics'
+        {{- end }}
+      resources:
+        limits:
+          cpu: 100m
+          memory: 10Mi
+        requests:
+          cpu: 100m
+          memory: 1Mi
+  restartPolicy: Never

--- a/charts/cosmotech-modeling-api/values.yaml
+++ b/charts/cosmotech-modeling-api/values.yaml
@@ -1,0 +1,41 @@
+nameOverride: cosmotech-modeling-api
+fullNameOverride: ""
+
+image:
+  repository: ghcr.io/cosmo-tech/cosmotech-modeling-api
+  tag: "latest"
+  pullPolicy: Always
+  credentials:
+    registry: ""
+    username: ""
+    password: ""
+
+service:
+  type: ClusterIP
+  port: 8080
+
+serviceMonitor:
+  enabled: true
+  namespace: cosmotech-monitoring
+  port: 9100
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+config:
+  apiSettings: {}
+  argoSettings: {}
+  s3:
+    user: {}
+    password: {}


### PR DESCRIPTION
This merges the first modeling api chart release from its own repo into this monorepo.
It tries to keep the history and merge seemlessly into the repo layout.

Later tags will come after if this works correctly.