### PR TITLE
Manually trigger and run the chart releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,17 @@
 name: Release Charts
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      chart_name:
+        description: "Name of the chart to release"
+        required: true
+        type: choice
+        options:
+          - cosmotech-api
+          - cosmotech-business-webapp
+          - cosmotech-copilot-api
+          - cosmotech-modeling-api
 
 jobs:
   release:
@@ -13,20 +21,41 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Compute repository name
+        run: |
+          echo "REPO_NAME=$(basename ${{ github.repository }})" >> "$GITHUB_ENV"
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Install chart releaser
+        run: |
+          cr_version=1.8.1
+          curl -sSL https://github.com/helm/chart-releaser/releases/download/v${cr_version}/chart-releaser_${cr_version}_linux_amd64.tar.gz -o cr.tgz
+          mkdir cr_bin
+          tar -xzf cr.tgz -C cr_bin
+          rm cr.tgz
+          echo "$PWD/cr_bin" >> "$GITHUB_PATH"
+
+      - name: Chart package
+        run: |
+          cr package ${{ inputs.chart_name }}
+
+      - name: Chart release
+        run: >
+          cr upload
+            --owner ${{ github.repository_owner }}
+            --git-repo ${{ env.REPO_NAME }}
+            --token ${{ secrets.GITHUB_TOKEN }}
+            --commit ${{ github.sha }}
+
+      - name: Index update
+        run: >
+          cr index
+            --owner ${{ github.repository_owner }}
+            --git-repo ${{ env.REPO_NAME }}
+            --token ${{ secrets.GITHUB_TOKEN }}
+            --push


### PR DESCRIPTION
The chart-releaser-action behavior (and options) does not fit well our wanted workflow for this repo. It wants to release all modified charts, even when their version did not change which leads to errors. On our side we would like to be able to do development commits on the main branch without having to release a chart and control when and which chart to release.

This can be done, with a bit more work, by not using the action but the chart releaser CLI directly to package and release a single selected chart on a manual trigger.

So the new workflow would be:
- do modifications on charts in the `main` branch (any number of charts can be work on concurrently)
- change chart version whenever you prefer: bump to next version after a tag or bump version before release
- when you want to release a specific chart (no matter the state of the others): manually trigger the `release` workflow, selecting the appropriate chart in the list
- just as before the job will package the chart, create a release based on the chart name and current chart version and update the gh-pages index file to make it available as a helm repository

TL;DR:
- operations are done using the cr CLI instead of the action
- only one chart can be released at a time
- this is now manually triggered