### PR TITLE
Add a continous chart and latest api deployment

### DIFF
--- a/.github/workflows/api_deploy.yml
+++ b/.github/workflows/api_deploy.yml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+# SPDX-License-Identifier: MIT
+name: API / Chart deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - charts/cosmotech-api/**
+      - .github/workflows/api_deploy.yml
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: api_warp
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - uses: azure/login@v2
+        with:
+          creds: "${{ secrets.AZURE_CREDENTIALS }}"
+
+      - uses: azure/use-kubelogin@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          kubelogin-version: 'latest'
+
+      - uses: azure/aks-set-context@v4
+        with:
+          cluster-name: "${{ vars.CLUSTER_NAME }}"
+          resource-group: "${{ vars.CLUSTER_RESOURCE_GROUP }}"
+          use-kubelogin: true
+
+      - name: Helm package
+        run: >
+          helm package
+          --destination ${{ runner.temp }}/package
+          charts/cosmotech-api/
+
+      - name: Write helm values
+        run: |
+          echo '${{ vars.HELM_VALUES }}' > values.yaml
+          cat values.yaml
+
+      - name: Helm upgrade/install
+        run: >
+          helm upgrade
+          --install
+          --wait
+          --namespace ${{ vars.CLUSTER_NAMESPACE }}
+          --reset-values
+          --values values.yaml
+          --set argo.imageCredentials.password=${{ secrets.ACR_CREDENTIALS_PASSWORD }}
+          --set config.csm.platform.containerRegistry.password=${{ secrets.ACR_CREDENTIALS_PASSWORD }}
+          --set config.csm.platform.identityProvider.identity.clientSecret=${{ secrets.KEYCLOAK_CLIENT_SECRET }}
+          --set config.csm.platform.s3.secretAccessKey=${{ secrets.S3_PASSWORD }}
+          --set config.csm.platform.twincache.password=${{ secrets.REDIS_PASSWORD }}
+          cosmotech-api-ci
+          ${{ runner.temp }}/package/cosmotech-api-*.tgz
+
+      - name: Helm test
+        run: >
+          helm test
+          --namespace ${{ vars.CLUSTER_NAMESPACE }}
+          cosmotech-api-ci


### PR DESCRIPTION
For now this is deployed on an existing tenant, with existing values. It's working (but maybe by chance regarding the keycloak settings).

In the end we probably want to have a dedicated tenant/namespace for the CI/CD with keycloak clients setup correctly for this manual helm release instead of deploying a second api in an existing tenant where the keycloak client are setup for the first api (in terms of redirect URI,...)

The deploy values are currently set in a Github Actions variable (similar to the modeling api), but this is not very handy to save a large-ish YAML file in there. For the modeling api, in the other repo, I originally had the values.yaml file in the repo, but I'm not sure this is a good idea so I put the values in the Github environment variables. To be discussed.