### PR TITLE
Use helm comment instead of YAML comment for copyrights

### DIFF
--- a/charts/cosmotech-api/templates/deployment.yaml
+++ b/charts/cosmotech-api/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/cosmotech-api/templates/hpa.yaml
+++ b/charts/cosmotech-api/templates/hpa.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/charts/cosmotech-api/templates/ingress.yaml
+++ b/charts/cosmotech-api/templates/ingress.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- if .Values.ingress.enabled -}}
 {{- $kubeVersion := .Capabilities.KubeVersion.GitVersion -}}
 {{- $fullName := include "cosmotech-api.fullname" . -}}

--- a/charts/cosmotech-api/templates/network_policies.yaml
+++ b/charts/cosmotech-api/templates/network_policies.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- if .Values.networkPolicy.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/cosmotech-api/templates/rbac.yaml
+++ b/charts/cosmotech-api/templates/rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/cosmotech-api/templates/registry.secret.yaml
+++ b/charts/cosmotech-api/templates/registry.secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- if .Values.imageCredentials.registry }}
 apiVersion: v1
 kind: Secret

--- a/charts/cosmotech-api/templates/secret.yaml
+++ b/charts/cosmotech-api/templates/secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- $baseConfig := include "cosmotech-api.baseConfig" . | fromYaml -}}
 {{- $mergedConfig := mustMergeOverwrite (dict) .Values.config $baseConfig  -}}
 kind: Secret

--- a/charts/cosmotech-api/templates/service.yaml
+++ b/charts/cosmotech-api/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/cosmotech-api/templates/serviceaccount.yaml
+++ b/charts/cosmotech-api/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/cosmotech-api/templates/servicemonitor.yaml
+++ b/charts/cosmotech-api/templates/servicemonitor.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- if .Values.api.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/cosmotech-api/templates/tests/test-access-openapi.yaml
+++ b/charts/cosmotech-api/templates/tests/test-access-openapi.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- $contextPath := include "cosmotech-api.contextPath" . -}}
 apiVersion: v1
 kind: Pod

--- a/charts/cosmotech-api/templates/tests/test-access-swaggerui.yaml
+++ b/charts/cosmotech-api/templates/tests/test-access-swaggerui.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- $contextPath := include "cosmotech-api.contextPath" . -}}
 apiVersion: v1
 kind: Pod

--- a/charts/cosmotech-business-webapp/templates/functions-deployment.yaml
+++ b/charts/cosmotech-business-webapp/templates/functions-deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/cosmotech-business-webapp/templates/functions-secret.yaml
+++ b/charts/cosmotech-business-webapp/templates/functions-secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cosmotech-business-webapp/templates/functions-service.yaml
+++ b/charts/cosmotech-business-webapp/templates/functions-service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/cosmotech-business-webapp/templates/webapp-server-deployment.yaml
+++ b/charts/cosmotech-business-webapp/templates/webapp-server-deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/cosmotech-business-webapp/templates/webapp-server-ingress.yaml
+++ b/charts/cosmotech-business-webapp/templates/webapp-server-ingress.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/cosmotech-business-webapp/templates/webapp-server-service.yaml
+++ b/charts/cosmotech-business-webapp/templates/webapp-server-service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/cosmotech-copilot-api/templates/deployment.yaml
+++ b/charts/cosmotech-copilot-api/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/cosmotech-copilot-api/templates/ingress.yaml
+++ b/charts/cosmotech-copilot-api/templates/ingress.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/cosmotech-copilot-api/templates/secret.yaml
+++ b/charts/cosmotech-copilot-api/templates/secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cosmotech-copilot-api/templates/service.yaml
+++ b/charts/cosmotech-copilot-api/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/cosmotech-modeling-api/templates/config.yaml
+++ b/charts/cosmotech-modeling-api/templates/config.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/cosmotech-modeling-api/templates/deployment.yaml
+++ b/charts/cosmotech-modeling-api/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/cosmotech-modeling-api/templates/pvc.yaml
+++ b/charts/cosmotech-modeling-api/templates/pvc.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- if .Values.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/cosmotech-modeling-api/templates/registry_secrets.yaml
+++ b/charts/cosmotech-modeling-api/templates/registry_secrets.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- define "cosmotech-modeling-api.registrySecret" }}
 {{- $existingSecret := lookup "v1" "Secret" .globals.Release.Namespace .secretName }}
 {{- $credentialsInValues := or .credentials.registry .credentials.username .credentials.password }}

--- a/charts/cosmotech-modeling-api/templates/service.yaml
+++ b/charts/cosmotech-modeling-api/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/cosmotech-modeling-api/templates/servicemonitor.yaml
+++ b/charts/cosmotech-modeling-api/templates/servicemonitor.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 {{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/cosmotech-modeling-api/templates/tests/connection.yaml
+++ b/charts/cosmotech-modeling-api/templates/tests/connection.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
-# SPDX-License-Identifier: MIT
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2025 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
This should avoid issues with '{{- if' blocks where the first YAML line of a ressource might get merged with the last comment line This then causes issues because we are missing a data line in the kubernetes resource definition.
It's easier to use Helm comments to avoid injecting them into the YAML than making sure the rendered YAML is valid in all cases.