### PR TITLE
Constrain workflow input with a fixed set of values

### DIFF
--- a/.github/workflows/modeling_api_restart.yml
+++ b/.github/workflows/modeling_api_restart.yml
@@ -8,7 +8,10 @@ on:
       imageTag:
         description: "Docker image tag that was updated"
         required: true
-        type: string
+        type: choice
+        options:
+          - continuous
+          - nightly
 
 jobs:
   restart:


### PR DESCRIPTION
This should reduce risks for a 'bash injection' vector attack from non-validated input