### PR TITLE
Allow network traffic on the modelin api pod

### DIFF
--- a/charts/cosmotech-modeling-api/templates/deployment.yaml
+++ b/charts/cosmotech-modeling-api/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
+        networking/traffic-allowed: "yes"
         {{- include "cosmotech-modeling-api.selectorLabels" . | nindent 8 }}
     spec:
       imagePullSecrets:


### PR DESCRIPTION
This should now make it compatible with a context where the run api is also deployed