### PR TITLE
Add storage resources for the modeling api pods

### DIFF
--- a/charts/cosmotech-modeling-api/README.md
+++ b/charts/cosmotech-modeling-api/README.md
@@ -28,7 +28,7 @@ Cosmo Tech Modeling API
 | persistence.storageClass | string | `""` | PVC storage class |
 | podAnnotations | object | `{}` | Additional pod annotations |
 | podSecurityContext | object | `{"fsGroup":1001,"fsGroupChangePolicy":"Always","supplementalGroups":[],"sysctls":[]}` | Security context injected at pod level |
-| resources | object | `{"limits":{"cpu":"1","memory":"256Mi"},"requests":{"cpu":"1","memory":"256Mi"}}` | Resources values |
+| resources | object | `{"limits":{"cpu":"1","ephemeral-storage":"2Gi","memory":"256Mi"},"requests":{"cpu":"1","ephemeral-storage":"50Mi","memory":"256Mi"}}` | Resources values |
 | service.port | int | `8080` | Service port number |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceMonitor.enabled | bool | `false` | Enable monitoring service |

--- a/charts/cosmotech-modeling-api/templates/tests/connection.yaml
+++ b/charts/cosmotech-modeling-api/templates/tests/connection.yaml
@@ -39,7 +39,9 @@ spec:
         limits:
           cpu: 1000m
           memory: 20Mi
+          ephemeral-storage: 100Mi
         requests:
           cpu: 100m
           memory: 10Mi
+          ephemeral-storage: 50Mi
   restartPolicy: Never

--- a/charts/cosmotech-modeling-api/values.yaml
+++ b/charts/cosmotech-modeling-api/values.yaml
@@ -72,9 +72,11 @@ resources:
   limits:
     cpu: "1"
     memory: 256Mi
+    ephemeral-storage: 2Gi
   requests:
     cpu: "1"
     memory: 256Mi
+    ephemeral-storage: 50Mi
 
 # -- Node selector values
 nodeSelector: {}


### PR DESCRIPTION
Add ephemal-storage requests/limits as recommended by SonarQube The default values for the api pod is taken from the bitnami presets which all have a 50Mi/2Gi setup at this time