### PR TITLE
Add a headless service for the modeling api

### DIFF
--- a/charts/cosmotech-modeling-api/templates/service_headless.yaml
+++ b/charts/cosmotech-modeling-api/templates/service_headless.yaml
@@ -1,0 +1,19 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (C) 2022-2026 Cosmo Tech
+SPDX-License-Identifier: MIT
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cosmotech-modeling-api.fullname" . }}-headless
+  labels:
+    {{- include "cosmotech-modeling-api.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "cosmotech-modeling-api.selectorLabels" . | nindent 4 }}

--- a/charts/cosmotech-modeling-api/templates/statefulset.yaml
+++ b/charts/cosmotech-modeling-api/templates/statefulset.yaml
@@ -13,6 +13,7 @@ spec:
   selector:
     matchLabels:
       {{- include "cosmotech-modeling-api.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "cosmotech-modeling-api.fullname" . }}-headless
   template:
     metadata:
       annotations:


### PR DESCRIPTION
StatefulSet usually require to be bound to a headless service
Here we might not really need this, but at least this is a standard configuration