### PR TITLE
Update the Azure/use-kubelogin action to its actual latest version

### DIFF
--- a/.github/workflows/api_deploy.yml
+++ b/.github/workflows/api_deploy.yml
@@ -30,7 +30,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: azure/use-kubelogin@v1
+      - uses: azure/use-kubelogin@v1.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/api_restart.yml
+++ b/.github/workflows/api_restart.yml
@@ -20,7 +20,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: azure/use-kubelogin@v1
+      - uses: azure/use-kubelogin@v1.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/modeling_api_deploy.yml
+++ b/.github/workflows/modeling_api_deploy.yml
@@ -36,7 +36,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: azure/use-kubelogin@v1
+      - uses: azure/use-kubelogin@v1.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/modeling_api_restart.yml
+++ b/.github/workflows/modeling_api_restart.yml
@@ -28,7 +28,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: azure/use-kubelogin@v1
+      - uses: azure/use-kubelogin@v1.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Currently, specifying a generic 'v1' does not automatically pick up the latest version 1 release
Explicitly pinning a major.minor version should fix it, as well as allowing dependabot to report future new versions
See https://github.com/Azure/use-kubelogin/issues/235#issuecomment-4368282125