### PR TITLE
chore: bump chart version/appVersion to 4.2.3-onprem

### DIFF
--- a/charts/cosmotech-api/Chart.yaml
+++ b/charts/cosmotech-api/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.3-onprem
+version: 4.2.4-onprem
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.2.3-onprem"
+appVersion: "4.2.4-onprem"

--- a/charts/cosmotech-api/README.md
+++ b/charts/cosmotech-api/README.md
@@ -1,6 +1,6 @@
 # cosmotech-api
 
-![Version: 4.2.3-onprem](https://img.shields.io/badge/Version-4.2.3--onprem-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.2.3-onprem](https://img.shields.io/badge/AppVersion-4.2.3--onprem-informational?style=flat-square)
+![Version: 4.2.4-onprem](https://img.shields.io/badge/Version-4.2.4--onprem-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.2.4-onprem](https://img.shields.io/badge/AppVersion-4.2.4--onprem-informational?style=flat-square)
 
 Cosmo Tech Platform API
 
@@ -655,7 +655,7 @@ helm repo update
 Deploy the Cosmo Tech API using the Helm chart with the specified values:
 
 ```bash
-helm install ${RELEASE_NAME} cosmotech/cosmotech-api --namespace ${NAMESPACE} --version "4.2.3-onprem" --values - <<EOF
+helm install ${RELEASE_NAME} cosmotech/cosmotech-api --namespace ${NAMESPACE} --version "4.2.4-onprem" --values - <<EOF
 replicaCount: ${API_REPLICAS}
 api:
   version: ${API_VERSION_PATH}


### PR DESCRIPTION
Reducing our CVE load on v4